### PR TITLE
Remove “Publicist"

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,11 +333,6 @@
             <p>A fast, safe, and independent community of microblogs</p>
           </li>
           <li>
-            <h2><a href="https://roundwallsoftware.com/release-day/">Publicist</a></h2>
-            <em>by <a href="https://roundwallsoftware.com">Samuel Goodwin</a></em>
-            <p>A native app to make publishing to your Ghost and Wordpress blogs easier.</p>
-          </li>
-          <li>
             <h2><a href="https://skeletron.app/">Skeletron</a></h2>
             <em>by <a href="https://hanonno.com">Hanno ten Hoor</a></em>
             <p>A native app to make writing and publishing your Hugo site super simple.</p>


### PR DESCRIPTION
[As of May 5, 2021, Publicist was, effectively, dead](https://roundwallsoftware.com/blog/removing-publicist/).

This PR removes its entry.