### PR TITLE
Change Sequel Pro entry to Sequel Ace

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,9 +271,9 @@
             <p>The full power of applescript automation. Experience applescript made easy.</p>
           </li>
           <li>
-            <h2><a href="https://www.sequelpro.com">Sequel Pro</a></h2>
-            <em>by <a href="https://sequelpro.com/developers">Sequel Pro Devs</a></em> <span class="mac"></span> 
-            <p>A MySQL/MariaDB management GUI with just the greatest icon in the world.</p>
+            <h2><a href="https://www.sequel-ace.com">Sequel Ace</a></h2>
+            <em>by <a href="https://github.com/Sequel-Ace/Sequel-Ace">Sequel Ace Devs</a></em> <span class="mac"></span> 
+            <p>A MySQL/MariaDB management GUI, forked from Sequel Pro.</p>
           </li>
           <li>
             <h2><a href="https://subethaedit.net">SubEthaEdit</a></h2>


### PR DESCRIPTION
Sequel Pro is no longer in active development [per #3705](https://github.com/sequelpro/sequelpro/issues/3705). Entry changed to reflect the fact that Sequel Ace is an actively maintained fork.