### PR TITLE
Remove Feed Hawk.

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,11 +100,6 @@
             <p>A Mac app to help you find, preview, and subscribe to blogs.</p>
           </li>
           <li>
-            <h2><a href="https://www.goldenhillsoftware.com/feed-hawk/">Feed Hawk</a></h2> 
-            <em>by <a href="https://www.goldenhillsoftware.com/blog/"> Golden Hill Software</a></em> <span class="ios"></span>
-            <p>Subscribe to a website’s RSS feed from within Safari.</p>
-          </li>
-          <li>
             <h2><a href="http://cocoacake.net/apps/fiery/">Fiery Feeds</a></h2>
             <em>by <a href="http://blog.cocoacake.net">CocoaCake</a></em> <span class="ios"></span>
             <p>A feature-loaded reader for iOS.</p>


### PR DESCRIPTION
I incorporated Feed Hawk’s functionality into Unread and removed Feed Hawk from the App Store. Therefore this pull request removes Feed Hawk from the list of apps.