### PR TITLE
Update Unread to reflect release of Unread for Mac. Remove Feed Hawk.

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,11 +108,6 @@
             <p>A Mac app to help you find, preview, and subscribe to blogs.</p>
           </li>
           <li>
-            <h2><a href="https://www.goldenhillsoftware.com/feed-hawk/">Feed Hawk</a></h2>
-            <em>by <a href="https://www.goldenhillsoftware.com/blog/"> Golden Hill Software</a></em> <span class="ios"></span>
-            <p>Subscribe to a website’s RSS feed from within Safari.</p>
-          </li>
-          <li>
             <h2><a href="http://cocoacake.net/apps/fiery/">Fiery Feeds</a></h2>
             <em>by <a href="http://blog.cocoacake.net">CocoaCake</a></em> <span class="ios"></span>
             <p>A feature-loaded reader for iOS.</p>
@@ -169,8 +164,8 @@
           </li>
           <li>
             <h2><a href="https://www.goldenhillsoftware.com/unread/">Unread</a></h2>
-            <em>by <a href="https://www.goldenhillsoftware.com/blog/"> Golden Hill Software</a></em> <span class="ios"></span>
-            <p>A beautiful RSS reader for iOS that supports syncing.</p>
+            <em>by <a href="https://www.goldenhillsoftware.com/blog/"> Golden Hill Software</a></em> <span class="mac"></span> <span class="ios"> <span class="ipad"></span>
+            <p>An RSS reader with beautiful typography and a variety of color themes for Mac, iPhone, and iPad.</p>
           </li>
           <li>
             <h2><a href="https://www.vienna-rss.com/">ViennaRSS</a></h2>


### PR DESCRIPTION
I just released Unread for Mac. This PR makes these changes:

- Updates Unread’s entry to reflect the release of Unread for Mac.
- Removed Feed Hawk (I folded its functionality into Unread and discontinued it a while back.)